### PR TITLE
Update argmin dependency to version v0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ text_io = "0.1"
 computus = "1.0"
 serde = { version = "1.0.*", features = ["derive"] }
 serde_json = "1.0.*"
-argmin = "0.4"
+argmin = { version = "0.6.0", default-features = false }
 yahoo_finance_api = "1.2.2"
 gurufocus_api = "0.6"
 rand = "0.8"


### PR DESCRIPTION
This commit updates argmin from version 0.4 to v0.6.0-rc.2. The dependency on serde is optional in v0.6, and can be turned off by disabling the default features. Therefore it is not necessary anymore to implement `Serialize` and `Deserialize` for the problem.

Feel free to close this PR if you are not interested in updating argmin. If you are interested in updating, but you don't want to use a release candidate, then you can just leave this open and I'll make the necessary changes once 0.6 is out. 